### PR TITLE
Simplify payload

### DIFF
--- a/breezsdk/cmd/main.go
+++ b/breezsdk/cmd/main.go
@@ -3,9 +3,12 @@ package main
 import (
 	"context"
 	"log"
+	"os"
 
 	firebase "firebase.google.com/go"
 	"github.com/Netflix/go-env"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 
 	//"github.com/breez/notify/breezsdk"
 	"github.com/breez/notify/breezsdk"
@@ -22,7 +25,12 @@ func main() {
 	if err := config.Validate(); err != nil {
 		log.Fatalf("failed to validate config %v", err)
 	}
-	firebaseApp, err := firebase.NewApp(context.Background(), nil)
+
+	creds, err := google.CredentialsFromJSON(context.Background(), []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")), "https://www.googleapis.com/auth/firebase.messaging")
+	if err != nil {
+		log.Fatalf("failed to get google credentials %v", err)
+	}
+	firebaseApp, err := firebase.NewApp(context.Background(), nil, option.WithCredentials(creds))
 	if err != nil {
 		log.Fatalf("failed to create firebase application %v", err)
 	}

--- a/breezsdk/init.go
+++ b/breezsdk/init.go
@@ -1,8 +1,6 @@
 package breezsdk
 
 import (
-	"encoding/json"
-
 	"firebase.google.com/go/messaging"
 	"github.com/breez/notify/config"
 	"github.com/breez/notify/notify"
@@ -33,17 +31,12 @@ func createMessageFactory() services.FCMMessageBuilder {
 }
 
 func createSilentPush(notification *notify.Notification) (*messaging.Message, error) {
-	data, err := json.Marshal(notification.Data)
-	if err != nil {
-		return nil, err
-	}
+	data := notification.Data
+	data["notification_type"] = notification.Template
 
 	return &messaging.Message{
 		Token: notification.TargetIdentifier,
-		Data: map[string]string{
-			"notification_type": notification.Template,
-			"data":              string(data),
-		},
+		Data:  data,
 		Android: &messaging.AndroidConfig{
 			Priority: "high",
 		},

--- a/http/router.go
+++ b/http/router.go
@@ -32,7 +32,7 @@ func (p *PaymentReceivedPayload) ToNotification(query *MobilePushWebHookQuery) *
 		Template:         p.Template,
 		Type:             query.Platform,
 		TargetIdentifier: query.Token,
-		Data:             map[string]interface{}{"payment_hash": p.Data.PaymentHash},
+		Data:             map[string]string{"payment_hash": p.Data.PaymentHash},
 	}
 }
 
@@ -48,7 +48,7 @@ func (p *TxConfirmedPayload) ToNotification(query *MobilePushWebHookQuery) *noti
 		Template:         p.Template,
 		Type:             query.Platform,
 		TargetIdentifier: query.Token,
-		Data:             map[string]interface{}{"tx_id": p.Data.TxID},
+		Data:             map[string]string{"tx_id": p.Data.TxID},
 	}
 }
 
@@ -64,7 +64,7 @@ func (p *AddressTxsChangedPayload) ToNotification(query *MobilePushWebHookQuery)
 		Template:         p.Template,
 		Type:             query.Platform,
 		TargetIdentifier: query.Token,
-		Data:             map[string]interface{}{"address": p.Data.Address},
+		Data:             map[string]string{"address": p.Data.Address},
 	}
 }
 

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -23,7 +23,7 @@ type Notification struct {
 	Template         string
 	Type             string
 	TargetIdentifier string
-	Data             map[string]interface{}
+	Data             map[string]string
 }
 
 type Service interface {


### PR DESCRIPTION
In the notification payload moving to  `map[string]string ` instead of `map[string]interface{}` allows us to avoid nested level in the notification payload and better align with fcm structure.