### PR TITLE
feat(google): use FindDefaultCredentials and support Workload Identity

### DIFF
--- a/breezsdk/cmd/main.go
+++ b/breezsdk/cmd/main.go
@@ -11,39 +11,51 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
-	//"github.com/breez/notify/breezsdk"
 	"github.com/breez/notify/breezsdk"
 	"github.com/breez/notify/config"
 	"github.com/breez/notify/http"
 )
 
 func main() {
+	var err error
+	var firebaseApp *firebase.App
+	ctx := context.Background()
+
 	environment := os.Getenv("NOTIFIER_ENV")
-	// Read environment variables from breezsdk/cmd/config.env (if the file is available) on Dev environment
+	// Read environment variables from breezsdk/cmd/config.env (if the file is available) on Dev environment.
 	if environment == "development" {
-		if err := godotenv.Load("config.env"); err != nil && !os.IsNotExist(err) {
+		if err = godotenv.Load("config.env"); err != nil && !os.IsNotExist(err) {
 			log.Fatalln("Error loading .env file")
 		}
 	}
 
 	var config config.Config
-	if _, err := env.UnmarshalFromEnviron(&config); err != nil {
+	if _, err = env.UnmarshalFromEnviron(&config); err != nil {
 		log.Fatalf("failed to load config %v", err)
 	}
 
-	if err := config.Validate(); err != nil {
+	if err = config.Validate(); err != nil {
 		log.Fatalf("failed to validate config %v", err)
 	}
 
-	creds, err := google.CredentialsFromJSON(context.Background(), []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")), "https://www.googleapis.com/auth/firebase.messaging")
-	if err != nil {
-		log.Fatalf("failed to get google credentials %v", err)
+	if _, f := os.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS_JSON"); f {
+		creds, err := google.CredentialsFromJSON(context.Background(), []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")), "https://www.googleapis.com/auth/firebase.messaging")
+		if err != nil {
+			log.Fatalf("failed to get google credentials %v", err)
+		}
+		firebaseApp, err = firebase.NewApp(context.Background(), nil, option.WithCredentials(creds))
+		if err != nil {
+			log.Fatalf("failed to create firebase application %v", err)
+		}
+	} else {
+		projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+		firebaseApp, err = firebase.NewApp(ctx, &firebase.Config{ProjectID: projectID})
+		if err != nil {
+			log.Fatalf("failed to create firebase application %v", err)
+		}
 	}
-	firebaseApp, err := firebase.NewApp(context.Background(), nil, option.WithCredentials(creds))
-	if err != nil {
-		log.Fatalf("failed to create firebase application %v", err)
-	}
-	fcmMessaging, err := firebaseApp.Messaging(context.Background())
+
+	fcmMessaging, err := firebaseApp.Messaging(ctx)
 	if err != nil {
 		log.Fatalf("failed to create firebase messaging %v", err)
 	}
@@ -51,7 +63,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to create breezsdk notifier %v", err)
 	}
-	if err := http.Run(notifier, &config.HTTPConfig); err != nil {
+	if err = http.Run(notifier, &config.HTTPConfig); err != nil {
 		log.Printf("web server has exited with error")
 	}
 }


### PR DESCRIPTION
**BREAKING CHANGE**: `GOOGLE_APPLICATION_CREDENTIALS` expects a reference to a file containing the credentials, not the plaintext json.

See https://pkg.go.dev/golang.org/x/oauth2/google#FindDefaultCredentials. This however does standardize this package to use google tooling and allows users to take advantage of workload identity (among other things).