### PR TITLE
Rename AddressTxsChangedPayload to ..ConfirmedPayload

### DIFF
--- a/breezsdk/init.go
+++ b/breezsdk/init.go
@@ -24,7 +24,7 @@ func createMessageFactory() services.FCMMessageBuilder {
 		switch notification.Template {
 		case notify.NOTIFICATION_PAYMENT_RECEIVED,
 			notify.NOTIFICATION_TX_CONFIRMED,
-			notify.NOTIFICATION_ADDRESS_TXS_CHANGED,
+			notify.NOTIFICATION_ADDRESS_TXS_CONFIRMED,
 			notify.NOTIFICATION_LNURLPAY_INFO,
 			notify.NOTIFICATION_LNURLPAY_INVOICE:
 

--- a/http/router.go
+++ b/http/router.go
@@ -103,17 +103,17 @@ func (p *TxConfirmedPayload) ToNotification(query *MobilePushWebHookQuery) *noti
 	}
 }
 
-type AddressTxsChangedPayload struct {
-	Template string `json:"template" binding:"required,eq=address_txs_changed"`
+type AddressTxsConfirmedPayload struct {
+	Template string `json:"template" binding:"required,eq=address_txs_confirmed"`
 	Data     struct {
 		Address string `json:"address" binding:"required"`
 	} `json:"data"`
 }
 
-func (p *AddressTxsChangedPayload) ToNotification(query *MobilePushWebHookQuery) *notify.Notification {
+func (p *AddressTxsConfirmedPayload) ToNotification(query *MobilePushWebHookQuery) *notify.Notification {
 	return &notify.Notification{
 		Template:         p.Template,
-		DisplayMessage:   "Address transactions changed",
+		DisplayMessage:   "Address transactions confirmed",
 		Type:             query.Platform,
 		TargetIdentifier: query.Token,
 		AppData:          query.AppData,
@@ -148,7 +148,7 @@ func addWebHookRouter(r *gin.RouterGroup, notifier *notify.Notifier) {
 		}
 
 		// Find a matching notification payload
-		payloads := []NotificationConvertible{&PaymentReceivedPayload{}, &TxConfirmedPayload{}, &AddressTxsChangedPayload{}, &LnurlPayInfoPayload{}, &LnurlPayInvoicePayload{}}
+		payloads := []NotificationConvertible{&PaymentReceivedPayload{}, &TxConfirmedPayload{}, &AddressTxsConfirmedPayload{}, &LnurlPayInfoPayload{}, &LnurlPayInvoicePayload{}}
 		var validPayload NotificationConvertible
 		for _, p := range payloads {
 			if err := c.ShouldBindBodyWith(p, binding.JSON); err != nil {

--- a/http/router_test.go
+++ b/http/router_test.go
@@ -64,19 +64,19 @@ func TestAddressTXsChangedHook(t *testing.T) {
 		Platform: "android",
 		Token:    "1234",
 	}
-	txAddresTXsChangedPayload := AddressTxsChangedPayload{
-		Template: notify.NOTIFICATION_ADDRESS_TXS_CHANGED,
+	txAddressTxsConfirmedPayload := AddressTxsConfirmedPayload{
+		Template: notify.NOTIFICATION_ADDRESS_TXS_CONFIRMED,
 		Data: struct {
 			Address string "json:\"address\" binding:\"required\""
 		}{
 			Address: "1234",
 		},
 	}
-	body, err := json.Marshal(txAddresTXsChangedPayload)
+	body, err := json.Marshal(txAddressTxsConfirmedPayload)
 	if err != nil {
 		t.Fatalf("failed to marshal notification %v", err)
 	}
-	expected := txAddresTXsChangedPayload.ToNotification(&query)
+	expected := txAddressTxsConfirmedPayload.ToNotification(&query)
 	testValidNotification(t, "/api/v1/notify?platform=android&token=1234", body, expected)
 }
 

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -12,7 +12,7 @@ import (
 const (
 	NOTIFICATION_PAYMENT_RECEIVED    = "payment_received"
 	NOTIFICATION_TX_CONFIRMED        = "tx_confirmed"
-	NOTIFICATION_ADDRESS_TXS_CHANGED = "address_txs_changed"
+	NOTIFICATION_ADDRESS_TXS_CONFIRMED = "address_txs_confirmed"
 	NOTIFICATION_LNURLPAY_INFO       = "lnurlpay_info"
 	NOTIFICATION_LNURLPAY_INVOICE    = "lnurlpay_invoice"
 )


### PR DESCRIPTION
Rename a few structs and constants to better reflect the swap tx context.

More specifically, the swap tx notification is sent when a new tx to the swap address is confirmed.