### PR TITLE
Add Boltz webhook handling

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -10,11 +10,12 @@ import (
 )
 
 const (
-	NOTIFICATION_PAYMENT_RECEIVED    = "payment_received"
-	NOTIFICATION_TX_CONFIRMED        = "tx_confirmed"
+	NOTIFICATION_PAYMENT_RECEIVED      = "payment_received"
+	NOTIFICATION_TX_CONFIRMED          = "tx_confirmed"
 	NOTIFICATION_ADDRESS_TXS_CONFIRMED = "address_txs_confirmed"
-	NOTIFICATION_LNURLPAY_INFO       = "lnurlpay_info"
-	NOTIFICATION_LNURLPAY_INVOICE    = "lnurlpay_invoice"
+	NOTIFICATION_LNURLPAY_INFO         = "lnurlpay_info"
+	NOTIFICATION_LNURLPAY_INVOICE      = "lnurlpay_invoice"
+	NOTIFICATION_SWAP_UPDATED          = "swap_updated"
 )
 
 var (


### PR DESCRIPTION
This PR adds `SwapUpdatedPayload` to handle [Boltz webhook](https://docs.boltz.exchange/v/api/webhooks) requests.

@roeierez Is it worth filtering out some of the status updates on the notifier, or let the Notification Plugin decide which to ignore? I imagine SwapCreated, InvoiceSet and potentially Mempool statuses could be ignored.  