### PR TITLE
Add swap notification to the message factory

### DIFF
--- a/breezsdk/init.go
+++ b/breezsdk/init.go
@@ -26,7 +26,8 @@ func createMessageFactory() services.FCMMessageBuilder {
 			notify.NOTIFICATION_TX_CONFIRMED,
 			notify.NOTIFICATION_ADDRESS_TXS_CONFIRMED,
 			notify.NOTIFICATION_LNURLPAY_INFO,
-			notify.NOTIFICATION_LNURLPAY_INVOICE:
+			notify.NOTIFICATION_LNURLPAY_INVOICE,
+			notify.NOTIFICATION_SWAP_UPDATED:
 
 			return createPush(notification)
 		}


### PR DESCRIPTION
This PR fixes the issue where the `swap_updated` template is not recognised by the message factory by adding `NOTIFICATION_SWAP_UPDATED` to the accepted templates.