### PR TITLE
Add LNURL-verify notification handling

### DIFF
--- a/notify/notify.go
+++ b/notify/notify.go
@@ -15,6 +15,7 @@ const (
 	NOTIFICATION_ADDRESS_TXS_CONFIRMED = "address_txs_confirmed"
 	NOTIFICATION_LNURLPAY_INFO         = "lnurlpay_info"
 	NOTIFICATION_LNURLPAY_INVOICE      = "lnurlpay_invoice"
+	NOTIFICATION_LNURLPAY_VERIFY       = "lnurlpay_verify"
 	NOTIFICATION_SWAP_UPDATED          = "swap_updated"
 	NOTIFICATION_INVOICE_REQUEST       = "invoice_request"
 )


### PR DESCRIPTION
This PR adds handling for the `lnurlpay_verify` template type which gets sent via push notification to the device

LUD-21: https://github.com/lnurl/luds/blob/luds/21.md

LNURL service PR: https://github.com/breez/breez-lnurl/pull/20
SDK PR: https://github.com/breez/breez-sdk-liquid/pull/911