### PR TITLE
Only pass-through verify_url if set in the request

### DIFF
--- a/http/router.go
+++ b/http/router.go
@@ -67,18 +67,22 @@ func (p *LnurlPayInvoicePayload) RequiresCallback() bool {
 }
 
 func (p *LnurlPayInvoicePayload) ToNotification(query *MobilePushWebHookQuery) *notify.Notification {
-	return &notify.Notification{
+	notification := notify.Notification{
 		Template:         p.Template,
 		DisplayMessage:   "Invoice requested",
 		Type:             query.Platform,
 		TargetIdentifier: query.Token,
 		AppData:          query.AppData,
 		Data: map[string]interface{}{
-			"amount":     p.Data.Amount,
-			"reply_url":  p.Data.ReplyURL,
-			"verify_url": p.Data.VerifyURL,
+			"amount":    p.Data.Amount,
+			"reply_url": p.Data.ReplyURL,
 		},
 	}
+	if p.Data.VerifyURL != nil {
+		notification.Data["verify_url"] = p.Data.VerifyURL
+	}
+
+	return &notification
 }
 
 type LnurlPayVerifyPayload struct {


### PR DESCRIPTION
This prevents a backwards compatibility issue where the Kotlin serialization of the `lnurlpay_invoice` request cannot be parsed because it contains an unknown `verify_url` key
```
[com.breez.misty.BreezForegroundService] {WARN} (2025-05-13 06:49:21.648) : Failed to process lnurl: Unexpected JSON token at offset 81: Encountered an unknown key 'verify_url' at path: $.reply_url
  Use 'ignoreUnknownKeys = true' in 'Json {}' builder to ignore unknown keys.
  JSON input: {"amount":1000000,"reply_url":"https://breez.fun/response/17913778238782819717","verify_url":"[https://breez.fun/lnurlpay/dangeross/{payment_hash}](https://breez.fun/lnurlpay/dangeross/%7Bpayment_hash%7D)"}
```